### PR TITLE
Fixes flash of unstyled text/content

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,16 +73,6 @@
         display: none;
       }
 
-      html.js #weather {
-        display: inline-block;
-        -webkit-transition: all 0.25s ease-in;
-        -moz-transition: all 0.25s ease-in;
-        -ms-transition: all 0.25s ease-in;
-        -o-transition: all 0.25s ease-in;
-        transition: all 0.25s ease-in;
-        min-width: 100px;
-      }
-
       #weather-text {
         font-style: italic;
       }
@@ -92,10 +82,16 @@
         font-size: 0.8em; /* 16px (icon height should match font x-height) */
       }
 
-      .shrunk {
-        -webkit-transform: scale(0);
-        -ms-transform: scale(0);
-        transform: scale(0);
+      .js .content {
+        -webkit-transition: all 0.25s ease-in;
+        -moz-transition: all 0.25s ease-in;
+        -ms-transition: all 0.25s ease-in;
+        -o-transition: all 0.25s ease-in;
+        transition: all 0.5s ease-in;
+        opacity: 0;
+      }
+      .js .wi {
+        min-width: 25px;
       }
 
     </style>
@@ -108,7 +104,7 @@
     <img src="MIDMKT-logo-white.png" alt="" />
 
     <div class="content">
-      <h1>A design and development studio in <div class="shrunk" id="weather"></div> San Francisco.</h1>
+      <h1>A design and development studio in <span id="weather"></span> San Francisco.</h1>
       <p>We build beautiful things for the web. Our team includes illustrators, UI/UX designers and experienced full stack developers.</p>
       <p class="inquire">Currently accepting clients. <a href="mailto:hello@midmkt.co?subject=Hello MIDMKT!">Inquire within.</a></p>
     </div>
@@ -175,12 +171,15 @@
             var weather = _.find(codes, {code: data});
             var condition = '<span class="currently">'+weather.adjective+'</span>';
             var icon = '<i class="wi wi-'+weather.wi+'"></i>';
-            $("#weather").html(condition+' '+icon);
-            $("#weather").fadeIn('fast');
-            $("#weather").toggleClass("shrunk");
-            $("#weather").css("min-width", "0");
+            $("#weather").html(condition+' '+icon).fadeIn('fast', function() {
+              window.setTimeout(function() {
+                $('.content').css('opacity', '1');
+              }, 500);
+            });
         } else {
             console.log('Failed. Expected weatherCode to be a number. It isn\`t.');
+            $('#weather').remove();
+            $('.content').css('opacity', '1');
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -99,6 +99,9 @@
       }
 
     </style>
+    <script>
+        document.getElementsByTagName('html')[0].className += ' js';
+    </script>
 
   </head>
   <body>
@@ -181,7 +184,6 @@
         }
     }
 
-    document.getElementsByTagName('html')[0].className += ' js';
     $(document).ready(function() {
         var weatherURL = "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20weather.forecast%20where%20woeid%20in%20(select%20woeid%20from%20geo.places(1)%20where%20text%3D%22san%20francisco%20%2C%20ca%22)&format=json&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys";
         var getWeather = $.getJSON( weatherURL, function(data) {

--- a/index.html
+++ b/index.html
@@ -4,9 +4,6 @@
   <head>
     <title>MIDMKT</title>
 
-    <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-
     <link rel="stylesheet" href="/weather/css/weather-icons.min.css">
 
     <style>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,20 @@
         text-decoration: none;
       }
 
+      #weather {
+        display: none;
+      }
+
+      html.js #weather {
+        display: inline-block;
+        -webkit-transition: all 0.25s ease-in;
+        -moz-transition: all 0.25s ease-in;
+        -ms-transition: all 0.25s ease-in;
+        -o-transition: all 0.25s ease-in;
+        transition: all 0.25s ease-in;
+        min-width: 100px;
+      }
+
       #weather-text {
         font-style: italic;
       }
@@ -77,6 +91,12 @@
         font-size: 0.8em; /* 16px (icon height should match font x-height) */
       }
 
+      .shrunk {
+        -webkit-transform: scale(0);
+        -ms-transform: scale(0);
+        transform: scale(0);
+      }
+
     </style>
 
   </head>
@@ -84,7 +104,7 @@
     <img src="MIDMKT-logo-white.png" alt="" />
 
     <div class="content">
-      <h1>A design and development studio in <span id="weather" style="display:none;"></span> San Francisco.</h1>
+      <h1>A design and development studio in <div class="shrunk" id="weather"></div> San Francisco.</h1>
       <p>We build beautiful things for the web. Our team includes illustrators, UI/UX designers and experienced full stack developers.</p>
       <p class="inquire">Currently accepting clients. <a href="mailto:hello@midmkt.co?subject=Hello MIDMKT!">Inquire within.</a></p>
     </div>
@@ -153,11 +173,14 @@
             var icon = '<i class="wi wi-'+weather.wi+'"></i>';
             $("#weather").html(condition+' '+icon);
             $("#weather").fadeIn('fast');
+            $("#weather").toggleClass("shrunk");
+            $("#weather").css("min-width", "0");
         } else {
             console.log('Failed. Expected weatherCode to be a number. It isn\`t.');
         }
     }
 
+    document.getElementsByTagName('html')[0].className += ' js';
     $(document).ready(function() {
         var weatherURL = "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20weather.forecast%20where%20woeid%20in%20(select%20woeid%20from%20geo.places(1)%20where%20text%3D%22san%20francisco%20%2C%20ca%22)&format=json&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys";
         var getWeather = $.getJSON( weatherURL, function(data) {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
   <head>
     <title>MIDMKT</title>
 

--- a/index.html
+++ b/index.html
@@ -91,6 +91,12 @@
         min-width: 25px;
       }
 
+      .hide {
+         position: absolute !important;
+         top: -9999px !important;
+         left: -9999px !important;
+      }
+
     </style>
     <script>
         document.getElementsByTagName('html')[0].className += ' js';
@@ -99,6 +105,9 @@
   </head>
   <body>
     <img src="MIDMKT-logo-white.png" alt="" />
+    <div class="font_preload hide">
+      <i class="wi wi-fog"></i>
+    </div>
 
     <div class="content">
       <h1>A design and development studio in <span id="weather"></span> San Francisco.</h1>


### PR DESCRIPTION
Previously when the weather came in it was a bit jarring. This fades in the .content block instead, after the weather has been fetched. 

Oh I also removed the bootstrap CSS since we didn't seem to use it / it didn't change how things looked for me.

Not all of these commits are strictly necessary (but maybe want them -- particularly the attempts at animating weather) for future ref? Feel free to git-rebase this branch if you want to remove that first commit, though.
